### PR TITLE
Bump Max Bounds of base & tasty Packages

### DIFF
--- a/tasty-wai.cabal
+++ b/tasty-wai.cabal
@@ -37,8 +37,8 @@ library
   -- other-modules:
   -- other-extensions:
 
-  build-depends:       base >=4.8 && <4.14
-                     , tasty >= 0.8 && < 1.3
+  build-depends:       base >= 4.8 && < 4.15
+                     , tasty >= 0.8 && < 1.4
                      , bytestring == 0.10.*
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
@@ -58,8 +58,8 @@ test-suite tests
   hs-source-dirs:      test
   main-is:             Test.hs
 
-  build-depends:       base >=4.8 && <4.14
-                     , tasty >= 0.8 && < 1.3
+  build-depends:       base >= 4.8 && < 4.14
+                     , tasty >= 0.8 && < 1.4
                      , wai == 3.2.*
                      , http-types >= 0.9 && < 0.13
                      , tasty-wai


### PR DESCRIPTION
The `tasty-wai` stackage package requires support for tasty v1.3.

This bumps the max bounds for both the tasty & base packages.

Refs commercialhaskell/stackage#5348