### PR TITLE
Support wai-extra 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for tasty-wai
 
+## 0.1.1.1 -- 2020-09-24
+
+* Support wai-extra 3.1
+
 ## 0.1.1.0 -- 2019-01-09
 
 * Add `buildRequestWithHeaders` function.

--- a/src/Test/Tasty/Wai.hs
+++ b/src/Test/Tasty/Wai.hs
@@ -31,6 +31,8 @@ import           Data.Monoid          ((<>))
 import           Network.HTTP.Types   (RequestHeaders, StdMethod)
 import qualified Network.HTTP.Types   as HTTP
 
+import           Test.HUnit.Lang      (HUnitFailure (HUnitFailure), formatFailureReason)
+
 import           Test.Tasty.Providers (IsTest (..), Progress (..), TestName,
                                        TestTree, singleTest, testFailed,
                                        testPassed)
@@ -58,7 +60,7 @@ instance IsTest Sess where
     -- 'Session a' isn't important for the test?
     E.try (runSession sess app) >>= either toFailure toPass
     where
-      toFailure (WaiTestFailure s) = testFailed <$> (formatMessage s)
+      toFailure (HUnitFailure _ s) = testFailed <$> (formatMessage (formatFailureReason s))
       toPass     _                 = pure (testPassed mempty)
 
 -- | Create an empty 'Request' using the given HTTP Method and route.

--- a/tasty-wai.cabal
+++ b/tasty-wai.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-wai
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            Test 'wai' endpoints via Test.Tasty
 description:         Helper functions and runners for testing wai endpoints using the Tasty testing infrastructure.
 license:             BSD3
@@ -40,10 +40,11 @@ library
 
   build-depends:       base >= 4.8 && < 4.15
                      , tasty >= 0.8 && < 1.4
-                     , bytestring == 0.10.*
+                     , bytestring >= 0.10 && < 0.12
                      , wai == 3.2.*
-                     , wai-extra == 3.0.*
+                     , wai-extra >= 3 && < 3.2
                      , http-types >= 0.9 && < 0.13
+                     , HUnit >= 1.6 && < 1.7
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This compiles and passes tests, but I'm not sure it's semantically correct. See https://github.com/yesodweb/wai/pull/817 for the relevant upstream change.

@mankyKitty , please review this.

closes #4