### PR TITLE
Allows tasty-1.4

### DIFF
--- a/tasty-wai.cabal
+++ b/tasty-wai.cabal
@@ -39,7 +39,7 @@ library
   -- other-extensions:
 
   build-depends:       base >= 4.8 && < 4.15
-                     , tasty >= 0.8 && < 1.4
+                     , tasty >= 0.8 && < 1.5
                      , bytestring >= 0.10 && < 0.12
                      , wai == 3.2.*
                      , wai-extra >= 3 && < 3.2
@@ -61,7 +61,7 @@ test-suite tests
   main-is:             Test.hs
 
   build-depends:       base >= 4.8 && < 4.15
-                     , tasty >= 0.8 && < 1.4
+                     , tasty >= 0.8 && < 1.5
                      , wai == 3.2.*
                      , http-types >= 0.9 && < 0.13
                      , tasty-wai


### PR DESCRIPTION
Related to commercialhaskell/stackage#5795; ~I haven't tested this locally, I just figured it would be easy to make the change and let CI yell at me if something broke~.

EDIT: I've since pulled this down and locally verified that `tasty-wai` builds and passes tests w/ `tasty-1.4`.