### PR TITLE
Allow GHC 9.6 (base 4.18)

### DIFF
--- a/tasty-wai.cabal
+++ b/tasty-wai.cabal
@@ -28,6 +28,7 @@ tested-with:         GHC == 7.10.3
                    , GHC == 8.8.3
                    , GHC == 8.10.1
                    , GHC == 9.0.1
+                   , GHC == 9.6.1
 
 source-repository head
     type: git
@@ -39,7 +40,7 @@ library
   -- other-modules:
   -- other-extensions:
 
-  build-depends:       base >= 4.8 && < 4.17
+  build-depends:       base >= 4.8 && < 4.19
                      , tasty >= 0.8 && < 1.5
                      , bytestring >= 0.10 && < 0.12
                      , wai == 3.2.*
@@ -61,7 +62,7 @@ test-suite tests
   hs-source-dirs:      test
   main-is:             Test.hs
 
-  build-depends:       base >= 4.8 && < 4.17
+  build-depends:       base >= 4.8 && < 4.19
                      , tasty >= 0.8 && < 1.5
                      , wai == 3.2.*
                      , http-types >= 0.9 && < 0.13


### PR DESCRIPTION
Tested using `cabal test -w ghc-9.6.1`.
